### PR TITLE
Fix: timestamp comments in GitIndex parser

### DIFF
--- a/write-yourself-a-git.org
+++ b/write-yourself-a-git.org
@@ -2428,13 +2428,13 @@ produce more elegant code in C than in Python…)
       content = raw[12:]
       idx = 0
       for i in range(0, count):
-          # Read creation time, as a unix timestamp (seconds since
+          # Read metadata modification time, as a unix timestamp (seconds since
           # 1970-01-01 00:00:00, the "epoch")
           ctime_s =  int.from_bytes(content[idx: idx+4], "big")
-          # Read creation time, as nanoseconds after that timestamps,
+          # Read metadata modification time, as nanoseconds after that timestamps,
           # for extra precision.
           ctime_ns = int.from_bytes(content[idx+4: idx+8], "big")
-          # Same for modification time: first seconds from epoch.
+          # Same for content modification time: first seconds from epoch.
           mtime_s = int.from_bytes(content[idx+8: idx+12], "big")
           # Then extra nanoseconds
           mtime_ns = int.from_bytes(content[idx+12: idx+16], "big")


### PR DESCRIPTION
Update comments for ctime and mtime timestamps to correctly describe their purposes:

- ctime: Changed from "creation time" to "metadata modification time" to reflect  that it tracks when file metadata (permissions, ownership) was last changed

- mtime: Improved description to "content modification time" to clarify  that it tracks only when file contents were modified

The code functionality remains unchanged; this is a documentation-only fix.