### PR TITLE
Include bat file for Windows users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__
 libwyag.py
 src
 wyag
+wyag.bat
 wyag.zip

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: article program
 article: write-yourself-a-git.html
-program: wyag libwyag.py
+program: wyag wyag.bat libwyag.py
 push: .last_push
 
 .PHONY: all article clean program push test
@@ -24,11 +24,11 @@ write-yourself-a-git.pdf: write-yourself-a-git.org wyag libwyag.py
     --eval "(setq org-export-with-broken-links t)" \
     -f org-latex-export-to-pdf
 
-wyag libwyag.py: write-yourself-a-git.org
+wyag wyag.bat libwyag.py: write-yourself-a-git.org
 	emacs --batch write-yourself-a-git.org -f org-babel-tangle
 
 wyag.zip: wyag libwyag.py LICENSE
-	zip -r wyag.zip wyag libwyag.py LICENSE
+	zip -r wyag.zip wyag wyag.bat libwyag.py LICENSE
 
 clean:
 	rm -f wyag libwyag.py write-yourself-a-git.html .last_push wyag.zip

--- a/write-yourself-a-git.org
+++ b/write-yourself-a-git.org
@@ -194,6 +194,14 @@ Then make it executable:
 
 You're done!
 
+For Windows users, you can additionally make a bat file to let you
+run the command from the command line without having to type the file
+extension:
+
+#+BEGIN_SRC bat :tangle wyag.bat
+  python wyag %*
+#+END_SRC
+
 # This is a noweb template to include in all three source files.
 #+NAME: file_header
 #+BEGIN_SRC shell :exports none


### PR DESCRIPTION
Closes #62. As I said there, for Windows Reasons™, you can't just run wyag from the command line in Windows. Thus one should include a file wyag.bat that will allow the user to to this. I got over my fear of org mode syntax to fix this. I decided to do it my way, and also not chmod +x it. The changes to the make file are also just my guesses as to what's right.